### PR TITLE
fix: добавлен Crawl-delay для Googlebot в robots.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ rundev.sh
 draft-config.yml
 .hugo_build.lock
 themes/bear-dev
+SEO_PLAN.md

--- a/content/robots.txt
+++ b/content/robots.txt
@@ -13,6 +13,9 @@ Disallow: /not-found/
 Disallow: /ip/
 
 
+User-agent: Googlebot
+Crawl-delay: 5
+
 User-agent: Yandex
 Disallow:
 Clean-param: p


### PR DESCRIPTION
## Summary

- Добавлен блок `User-agent: Googlebot` с `Crawl-delay: 5` в `robots.txt`
- Ранее задержка была настроена только для Yandex, GoogleBot не имел ограничений

## Test plan

- [ ] Проверить `https://jtprog.ru/robots.txt` после деплоя
- [ ] Убедиться, что Google Search Console не показывает ошибок сканирования